### PR TITLE
Adding Dockerfile and README instructions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,41 @@
+# build the API
+FROM golang:1.12.4-alpine as build_api
+
+WORKDIR /build
+
+COPY . /build
+
+RUN apk add --no-cache git
+RUN CGO_ENABLED=0 GOOS=linux go build -o docshelf cmd/server/main.go
+
+
+# build the UI
+FROM node:lts as build_ui
+
+WORKDIR /build
+
+COPY --from=build_api /build/ui /build
+
+RUN rm -rf ~/.elm
+RUN rm -rf elm-stuff/
+RUN rm -rf dist/
+RUN npm install elm
+RUN npm install parcel-bundler
+# RUN npm install --unsafe-perm=true --allow-root -g elm
+# RUN npm install --unsafe-perm=true --allow-root -g parcel-bundler
+# RUN npm install --unsafe-perm=true --allow-root
+# have to manually run parcel, because reasons
+RUN node ./node_modules/parcel-bundler/bin/cli.js build index.html
+
+
+# bring it all together
+FROM alpine
+
+WORKDIR /opt/app
+
+# listening on broadcast so that docshelf is easily available from the host machine
+ENV DS_HOST=0.0.0.0
+COPY --from=build_api /build/docshelf /opt/app/docshelf
+COPY --from=build_ui /build/dist /opt/app/ui/dist
+
+CMD ./docshelf

--- a/README.md
+++ b/README.md
@@ -7,6 +7,13 @@ A lightweight, team documentation solution that won't make you pull your hair ou
 ## !WIP!
 This project is still a pre-alpha work in progress and isn't suitable for any real use cases yet. Come back soon though! :smile:
 
+## Quickstart
+The fastest way to get up and running with docshelf is to build and run the docker container.
+```
+$ docker build -t docshelf .
+$ docker run -it -p 1337:1337 docshelf
+```
+
 ## Getting Started
 The easiest way to get started is to run docshelf in local mode. Assuming you have go installed:
 ```

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,3 +1,0 @@
-{
-  "lockfileVersion": 1
-}


### PR DESCRIPTION
This PR adds a multi-stage build for the docker container. This should be the preferred way to run docshelf now.