### PR TITLE
Adding user-level document pinning

### DIFF
--- a/docshelf.go
+++ b/docshelf.go
@@ -12,6 +12,7 @@ type User struct {
 	Name      string     `json:"name"`
 	Token     string     `json:"token"`
 	Groups    []string   `json:"groups"`
+	Pinned    []string   `json:"pinned"`
 	CreatedAt time.Time  `json:"createdAt"`
 	UpdatedAt time.Time  `json:"updatedAt"`
 	DeletedAt *time.Time `json:"deletedAt"`
@@ -53,7 +54,7 @@ type Policy struct {
 // A DocStore knows how to store and retrieve docshelf documents.
 type DocStore interface {
 	GetDoc(ctx context.Context, path string) (Doc, error)
-	ListDocs(ctx context.Context, path string, tags ...string) ([]Doc, error)
+	ListDocs(ctx context.Context, query string, tags ...string) ([]Doc, error)
 	PutDoc(ctx context.Context, doc Doc) error
 	TagDoc(ctx context.Context, path string, tags ...string) error
 	RemoveDoc(ctx context.Context, path string) error

--- a/http/http.go
+++ b/http/http.go
@@ -95,6 +95,7 @@ func (s Server) buildRoutes() chi.Router {
 		r.Route("/doc", func(r chi.Router) {
 			r.Post("/", s.DocHandler.PostDoc)
 			r.Get("/list", s.DocHandler.GetList)
+			r.Post("/pin/{path}", s.DocHandler.PinDoc) // TODO (erik): This should actually be reversed. Need to add IDs to documents.
 			r.Get("/{path}", s.DocHandler.GetDoc)
 			r.Delete("/{path}", s.DocHandler.DeleteDoc)
 		})


### PR DESCRIPTION
This PR closes #38 

After writing most of the code to add document pinning for users, I ended up scrapping it all and re-use the tagging functionality. Pinning a document will use the currently auth'd user's ID and apply a special tag to documents so they can be fetched later using the existing `ListDocs` features. This also means you can do full text searches of just your pinned documents for free.